### PR TITLE
[PR] [client] #259 랜딩 페이지 지도 이미지 가로 세로 비율 고정

### DIFF
--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -310,6 +310,7 @@ const ImageWrapper = styled.div`
       display: flex;
       flex-direction: column;
       width: 100%;
+      height: 66.667%;
     }
     &.animation {
       position: absolute;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#259 → dev

### 변경 사항
랜딩 페이지 내 지도 이미지의 가로 세로 비율을 고정하는 CSS 코드 추가