### PR TITLE
[PR] [client] #309 헤더 버튼의 텍스트 색상 설정 (누락된 버튼들에 대한 적용)

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -186,7 +186,11 @@ const MobileNavBtn = styled.button`
   `}
 `;
 
-const NonUserBtns = styled.div``;
+const NonUserBtns = styled.div`
+  .header-btn {
+    color: var(--color-black);
+  }
+`;
 
 const NonUserBtn = styled.button`
   font-size: 1rem;
@@ -221,7 +225,7 @@ const NonUserBtn = styled.button`
 const UserBtns = styled.div`
   display: flex;
   position: relative;
-  .mobile-header-btn {
+  .header-btn {
     color: var(--color-black);
   }
 `;
@@ -484,8 +488,12 @@ const Header = () => {
       )}
       {!isLogin && (
         <NonUserBtns>
-          <NonUserBtn onClick={handleGuestSignin}>게스트 로그인</NonUserBtn>
-          <NonUserBtn onClick={() => dispatch(signinModalOnAction)}>로그인</NonUserBtn>
+          <NonUserBtn className="header-btn" onClick={handleGuestSignin}>
+            게스트 로그인
+          </NonUserBtn>
+          <NonUserBtn className="header-btn" onClick={() => dispatch(signinModalOnAction)}>
+            로그인
+          </NonUserBtn>
           <NonUserBtn main onClick={() => dispatch(signupModalOnAction)}>
             회원가입
           </NonUserBtn>
@@ -494,7 +502,7 @@ const Header = () => {
       {isLogin && (
         <UserBtns>
           <NotificationContainer>
-            <NotificationBtn className="mobile-header-btn" onClick={HandleNotiClick}>
+            <NotificationBtn className="header-btn" onClick={HandleNotiClick}>
               <IoNotificationsOutline />
             </NotificationBtn>
             {isNotiBtnClicked && (
@@ -517,7 +525,7 @@ const Header = () => {
           <UserBtn onClick={HandleUserInfoClick}>
             <UserProfile size={1} user={{ id, nickname, image }} isDisabled />
           </UserBtn>
-          <MobileHamburgerBtn className="mobile-header-btn" onClick={handleHamburgerClick}>
+          <MobileHamburgerBtn className="header-btn" onClick={handleHamburgerClick}>
             <HiMenu />
           </MobileHamburgerBtn>
           {isUserBtnClicked && (


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#309 → dev

### 변경 사항
해더 컴포넌트 내 `로그인`, `게스트 로그인` 버튼의 텍스트 색상 `var(--color-black)`으로 설정